### PR TITLE
增加缓存机制，避免每次都查询域名解析提供商

### DIFF
--- a/src/DDNSSharp/Commands/AddCommand.cs
+++ b/src/DDNSSharp/Commands/AddCommand.cs
@@ -7,7 +7,7 @@ using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Net.NetworkInformation;
 using static DDNSSharp.Commands.Helpers.AddCommandHelper;
-using static DDNSSharp.Helpers.IpHelper;
+using static DDNSSharp.Helpers.IPHelper;
 
 namespace DDNSSharp.Commands
 {
@@ -23,7 +23,7 @@ namespace DDNSSharp.Commands
         /// <summary>
         /// 域名记录类型
         /// </summary>
-        [Option(CommandOptionType.SingleValue, Description = "Domain record type. Default is 'A'.")]
+        [Option(CommandOptionType.SingleValue, Description = "Domain record type. Default is 'A'.\nAllowed values are: A, AAAA.")]
         public DomainRecordType? Type { get; set; }
 
         /// <summary>

--- a/src/DDNSSharp/Commands/Helpers/ListCommandHelper.cs
+++ b/src/DDNSSharp/Commands/Helpers/ListCommandHelper.cs
@@ -14,6 +14,7 @@ namespace DDNSSharp.Commands.Helpers
 
             var domainColWidh = configs.Max(c => c.Domain.Length) + MARGIN;
             var typeColWidh = configs.Max(c => c.Type.ToString().Length) + MARGIN;
+            var interfaceColWidh = configs.Max(c => c.Interface.Length) + MARGIN;
             var providerColWidh = configs.Max(c => c.Provider.Length) + MARGIN;
             var lastSyncStatusColWidh = configs.Max(c => c.LastSyncStatus.ToString().Length) + MARGIN;
             var lastSyncTimeColWidh = configs.Max(c => c.LastSyncTime.ToString().Length) + MARGIN;
@@ -21,10 +22,11 @@ namespace DDNSSharp.Commands.Helpers
             foreach (var item in configs.OrderBy(c => c))
             {
                 output.WriteLine(
-                    "{1}|{0}{2}|{0}{3}|{0}{4}|{0}{5}",
+                    "{1}|{0}{2}|{0}{3}|{0}{4}|{0}{5}|{0}{6}",
                     String.Empty.PadRight(MARGIN),
                     item.Domain.PadRight(domainColWidh),
                     item.Type.ToString().PadRight(typeColWidh),
+                    item.Interface.PadRight(interfaceColWidh),
                     item.Provider.PadRight(providerColWidh),
                     item.LastSyncStatus.ToString().PadRight(lastSyncStatusColWidh),
                     item.LastSyncTime.ToString().PadRight(lastSyncTimeColWidh)

--- a/src/DDNSSharp/Commands/Helpers/ListCommandHelper.cs
+++ b/src/DDNSSharp/Commands/Helpers/ListCommandHelper.cs
@@ -15,15 +15,19 @@ namespace DDNSSharp.Commands.Helpers
             var domainColWidh = configs.Max(c => c.Domain.Length) + MARGIN;
             var typeColWidh = configs.Max(c => c.Type.ToString().Length) + MARGIN;
             var providerColWidh = configs.Max(c => c.Provider.Length) + MARGIN;
+            var lastSyncStatusColWidh = configs.Max(c => c.LastSyncStatus.ToString().Length) + MARGIN;
+            var lastSyncTimeColWidh = configs.Max(c => c.LastSyncTime.ToString().Length) + MARGIN;
 
             foreach (var item in configs.OrderBy(c => c))
             {
                 output.WriteLine(
-                    "{1}|{0}{2}|{0}{3}",
+                    "{1}|{0}{2}|{0}{3}|{0}{4}|{0}{5}",
                     String.Empty.PadRight(MARGIN),
                     item.Domain.PadRight(domainColWidh),
                     item.Type.ToString().PadRight(typeColWidh),
-                    item.Provider.PadRight(providerColWidh)
+                    item.Provider.PadRight(providerColWidh),
+                    item.LastSyncStatus.ToString().PadRight(lastSyncStatusColWidh),
+                    item.LastSyncTime.ToString().PadRight(lastSyncTimeColWidh)
                 );
             }
 

--- a/src/DDNSSharp/Commands/IpCommand.cs
+++ b/src/DDNSSharp/Commands/IpCommand.cs
@@ -2,7 +2,7 @@
 using McMaster.Extensions.CommandLineUtils;
 using System;
 using System.Net.Sockets;
-using static DDNSSharp.Helpers.IpHelper;
+using static DDNSSharp.Helpers.IPHelper;
 
 namespace DDNSSharp.Commands
 {

--- a/src/DDNSSharp/Commands/ListCommand.cs
+++ b/src/DDNSSharp/Commands/ListCommand.cs
@@ -1,8 +1,5 @@
 ﻿using DDNSSharp.Configs;
 using McMaster.Extensions.CommandLineUtils;
-using System;
-using System.Collections.Generic;
-using System.Text;
 using static DDNSSharp.Commands.Helpers.ListCommandHelper;
 
 namespace DDNSSharp.Commands

--- a/src/DDNSSharp/Commands/SyncCommand.cs
+++ b/src/DDNSSharp/Commands/SyncCommand.cs
@@ -1,25 +1,73 @@
-﻿using DDNSSharp.Providers;
+﻿using DDNSSharp.Configs;
+using DDNSSharp.Providers;
 using McMaster.Extensions.CommandLineUtils;
-using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using static DDNSSharp.Configs.DomainConfigHelper;
 
 namespace DDNSSharp.Commands
 {
     class SyncCommand
     {
+        /// <summary>
+        /// 强制刷新
+        /// </summary>
+        [Option(CommandOptionType.NoValue, Description = "Force synchronization, even if the IP address has not changed.")]
+        public bool Force { get; set; }
+
         int OnExecute(CommandLineApplication app, IConsole console)
         {
             var group = GetConfigs().GroupBy(c => c.Provider);
+
+            if (!group.Any())
+            {
+                console.Out.WriteLine("No domain name is currently configured, please add domain name information via the `add` command.");
+            }
+
             foreach (var domainConfigItems in group)
             {
                 var provider = ProviderHelper.GetInstanceByName(domainConfigItems.Key, app);
-                provider.Sync(domainConfigItems);
+
+                var items = domainConfigItems.AsEnumerable();
+
+                if (!Force)
+                {
+                    var ignores = items.Where(i => i.IsIPChanged() == false);
+                    OutputIgnoreDomainList(ignores, console);
+
+                    // 非强制刷新的情况下，只将 IP 地址变化的内容传给域名解析服务商
+                    items = items.Where(i => i.IsIPChanged());
+                }
+
+                provider.Sync(items);
+            }
+
+            if (group.Any())
+            {
+                // TODO 考虑在这里收集同步信息，展示成功、失败的数量
+                console.Out.WriteLine("Synchronization is complete.");
             }
 
             return 0;
+        }
+
+        void OutputIgnoreDomainList(IEnumerable<DomainConfigItem> domainConfigItems, IConsole console)
+        {
+            if (domainConfigItems.Any())
+            {
+                console.Out.WriteLine("The following domain names will not be synchronized because their IP addresses have not changed.");
+            }
+
+            foreach (var item in domainConfigItems)
+            {
+                // TODO 输出内容美化
+                console.Out.WriteLine($"{item.Domain} | {item.Type}");
+            }
+
+            if (domainConfigItems.Any())
+            {
+                console.Out.WriteLine();
+            }
         }
     }
 }

--- a/src/DDNSSharp/Commands/SyncCommand.cs
+++ b/src/DDNSSharp/Commands/SyncCommand.cs
@@ -62,6 +62,8 @@ namespace DDNSSharp.Commands
                     }
 
                     UpdateItem(item);
+
+                    console.Out.WriteLine("--------------------");
                 }
             }
 

--- a/src/DDNSSharp/Commands/SyncCommands/SyncContext.cs
+++ b/src/DDNSSharp/Commands/SyncCommands/SyncContext.cs
@@ -1,0 +1,9 @@
+﻿using DDNSSharp.Configs;
+
+namespace DDNSSharp.Commands.SyncCommands
+{
+    public class SyncContext
+    {
+        public DomainConfigItem DomainConfigItem { get; set; }
+    }
+}

--- a/src/DDNSSharp/Commands/SyncCommands/SyncStatus.cs
+++ b/src/DDNSSharp/Commands/SyncCommands/SyncStatus.cs
@@ -1,0 +1,25 @@
+﻿namespace DDNSSharp.Commands.SyncCommands
+{
+    public enum SyncStatus
+    {
+        /// <summary>
+        /// 无状态，例如域名刚刚被添加但尚未进行同步时将被标记为该状态
+        /// </summary>
+        None,
+
+        /// <summary>
+        /// 同步成功
+        /// </summary>
+        Success,
+
+        /// <summary>
+        /// 同步失败
+        /// </summary>
+        Failure,
+
+        /// <summary>
+        /// 忽略，当 IP 地址没有变化时将被标记为该状态
+        /// </summary>
+        Ignore
+    }
+}

--- a/src/DDNSSharp/Configs/DomainConfigHelper.cs
+++ b/src/DDNSSharp/Configs/DomainConfigHelper.cs
@@ -77,11 +77,27 @@ namespace DDNSSharp.Configs
             File.WriteAllBytes(DOMAIN_CONFIG_FILE_NAME, JsonSerializer.SerializeToUtf8Bytes(configs, DefaultOptions));
         }
 
+        public static void UpdateItem(DomainConfigItem item)
+        {
+            var configs = GetConfigs() ?? new List<DomainConfigItem>();
+
+            var i = configs.FindIndex(c => c.Equals(item));
+
+            if (i == -1)
+            {
+                throw new KeyNotFoundException($"No record with domain name '{item.Domain}' and type '{item.Type}' was found.");
+            }
+
+            configs[i] = item;
+            File.WriteAllBytes(DOMAIN_CONFIG_FILE_NAME, JsonSerializer.SerializeToUtf8Bytes(configs, DefaultOptions));
+        }
+
         public static int DeleteItem(DomainConfigItem item)
         {
             var configs = GetConfigs() ?? new List<DomainConfigItem>();
             var originalCount = configs.Count;
 
+            // TODO 这里不可能查到多个相等并返回 List 的
             configs = configs.Where(c => !c.Equals(item)).ToList();
             var currentCount = configs.Count;
 

--- a/src/DDNSSharp/Configs/DomainConfigItem.cs
+++ b/src/DDNSSharp/Configs/DomainConfigItem.cs
@@ -1,4 +1,5 @@
-﻿using DDNSSharp.Enums;
+﻿using DDNSSharp.Commands.SyncCommands;
+using DDNSSharp.Enums;
 using System;
 using System.Diagnostics.CodeAnalysis;
 using System.Net.Sockets;
@@ -37,9 +38,9 @@ namespace DDNSSharp.Configs
         public string Interface { get; set; }
 
         /// <summary>
-        /// 上次同步是否成功
+        /// 上次同步结果
         /// </summary>
-        public bool? IsLastSyncSuccess { get; set; }
+        public SyncStatus LastSyncStatus { get; set; }
 
         /// <summary>
         /// 上次同步的时间
@@ -52,9 +53,14 @@ namespace DDNSSharp.Configs
         public DateTime? LastSyncSuccessTime { get; set; }
 
         /// <summary>
-        /// 上次同步成功时的 IP 地址
+        /// 上次同步成功前的 IP 地址
         /// </summary>
-        public string LastSyncSuccessIP { get; set; }
+        public string LastSyncSuccessOriginalIP { get; set; }
+
+        /// <summary>
+        /// 上次同步成功后的 IP 地址
+        /// </summary>
+        public string LastSyncSuccessCurrentIP { get; set; }
 
         public int CompareTo([AllowNull] DomainConfigItem other)
         {

--- a/src/DDNSSharp/Configs/DomainConfigItem.cs
+++ b/src/DDNSSharp/Configs/DomainConfigItem.cs
@@ -1,6 +1,8 @@
 ﻿using DDNSSharp.Enums;
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Net.Sockets;
+using System.Text.Json.Serialization;
 
 namespace DDNSSharp.Configs
 {
@@ -15,6 +17,14 @@ namespace DDNSSharp.Configs
         /// 域名记录类型
         /// </summary>
         public DomainRecordType Type { get; set; }
+
+        [JsonIgnore]
+        public AddressFamily AddressFamily => Type switch
+        {
+            DomainRecordType.A => AddressFamily.InterNetwork,
+            DomainRecordType.AAAA => AddressFamily.InterNetworkV6,
+            _ => throw new NotSupportedException($"Not supported domain type '{Type}'.")
+        };
 
         /// <summary>
         /// DNS 提供商
@@ -32,14 +42,19 @@ namespace DDNSSharp.Configs
         public bool? IsLastSyncSuccess { get; set; }
 
         /// <summary>
-        /// 上次同步成功的时间
+        /// 上次同步的时间
+        /// </summary>
+        public DateTime? LastSyncTime { get; set; }
+
+        /// <summary>
+        /// 上次同步成功时的时间
         /// </summary>
         public DateTime? LastSyncSuccessTime { get; set; }
 
         /// <summary>
-        /// 上次同步的时间
+        /// 上次同步成功时的 IP 地址
         /// </summary>
-        public DateTime? LastSyncTime { get; set; }
+        public string LastSyncSuccessIP { get; set; }
 
         public int CompareTo([AllowNull] DomainConfigItem other)
         {

--- a/src/DDNSSharp/Configs/DomainConfigItemExtension.cs
+++ b/src/DDNSSharp/Configs/DomainConfigItemExtension.cs
@@ -1,0 +1,18 @@
+﻿using DDNSSharp.Helpers;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace DDNSSharp.Configs
+{
+    public static class DomainConfigItemExtension
+    {
+        public static bool IsIPChanged(this DomainConfigItem configItem)
+        {
+            var currentAddress = IPHelper.GetAddress(configItem.Interface, configItem.AddressFamily);
+            var lastAddress = configItem.LastSyncSuccessIP;
+
+            return currentAddress != lastAddress;
+        }
+    }
+}

--- a/src/DDNSSharp/Configs/DomainConfigItemExtension.cs
+++ b/src/DDNSSharp/Configs/DomainConfigItemExtension.cs
@@ -1,7 +1,4 @@
 ﻿using DDNSSharp.Helpers;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace DDNSSharp.Configs
 {
@@ -10,7 +7,7 @@ namespace DDNSSharp.Configs
         public static bool IsIPChanged(this DomainConfigItem configItem)
         {
             var currentAddress = IPHelper.GetAddress(configItem.Interface, configItem.AddressFamily);
-            var lastAddress = configItem.LastSyncSuccessIP;
+            var lastAddress = configItem.LastSyncSuccessCurrentIP;
 
             return currentAddress != lastAddress;
         }

--- a/src/DDNSSharp/DDNSSharp.csproj
+++ b/src/DDNSSharp/DDNSSharp.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <Version>0.0.1</Version>
+    <AssemblyName>ddnssharp</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DDNSSharp/Exceptions/Providers/ProviderNotConfiguredException.cs
+++ b/src/DDNSSharp/Exceptions/Providers/ProviderNotConfiguredException.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace DDNSSharp.Exceptions.Providers
+{
+    class ProviderNotConfiguredException : Exception
+    {
+        public ProviderNotConfiguredException() : base() { }
+
+        public ProviderNotConfiguredException(string message) : base(message) { }
+
+        public ProviderNotConfiguredException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/DDNSSharp/Helpers/IpHelper.cs
+++ b/src/DDNSSharp/Helpers/IpHelper.cs
@@ -6,7 +6,7 @@ using System.Net.Sockets;
 
 namespace DDNSSharp.Helpers
 {
-    public static class IpHelper
+    public static class IPHelper
     {
         /// <summary>
         /// 获取可用的网卡信息。当含有 IPv4 地址，或 Scope 为 Global 类型的 IPv6 地址时，认为其可用。

--- a/src/DDNSSharp/Providers/Aliyun/AliyunProvider.cs
+++ b/src/DDNSSharp/Providers/Aliyun/AliyunProvider.cs
@@ -155,10 +155,6 @@ namespace DDNSSharp.Providers.Aliyun
                     throw;
                 }
             }
-            finally
-            {
-                Console.WriteLine("--------------------");
-            }
         }
     }
 }

--- a/src/DDNSSharp/Providers/Aliyun/AliyunProvider.cs
+++ b/src/DDNSSharp/Providers/Aliyun/AliyunProvider.cs
@@ -3,7 +3,7 @@ using Aliyun.Acs.Core;
 using Aliyun.Acs.Core.Exceptions;
 using Aliyun.Acs.Core.Profile;
 using DDNSSharp.Attributes;
-using DDNSSharp.Configs;
+using DDNSSharp.Commands.SyncCommands;
 using DDNSSharp.Helpers;
 using McMaster.Extensions.CommandLineUtils;
 using System;
@@ -26,130 +26,138 @@ namespace DDNSSharp.Providers.Aliyun
             yield return new ProviderOption("--secret", "aliyun accessSecret", CommandOptionType.SingleValue);
         }
 
-        public override void Sync(IEnumerable<DomainConfigItem> domainConfigItems)
+        /// <summary>
+        /// Aliyun Client
+        /// </summary>
+        public DefaultAcsClient Client { get; set; }
+
+        public override void BeforeSync()
         {
             var config = GetConfig<AliyunConfig>();
 
             IClientProfile profile = DefaultProfile.GetProfile("cn-hangzhou", config.Id, config.Secret);
-            DefaultAcsClient client = new DefaultAcsClient(profile);
-            client.SetConnectTimeoutInMilliSeconds(60000);
-            client.SetReadTimeoutInMilliSeconds(60000);
 
-            foreach (var item in domainConfigItems)
+            Client = new DefaultAcsClient(profile);
+            Client.SetConnectTimeoutInMilliSeconds(60000);
+            Client.SetReadTimeoutInMilliSeconds(60000);
+        }
+
+        public override void Sync(SyncContext context)
+        {
+            var item = context.DomainConfigItem;
+
+            // 更新该记录的同步时间
+            item.LastSyncTime = DateTime.Now;
+
+            // 更新解析记录使用的请求，为了便于 catch 时获取相关数据，所以定义在 try 块外面
+            UpdateDomainRecordRequest updateRequest = null;
+
+            try
             {
-                Console.WriteLine($"Current domain: {item.Domain}");
+                string recordId;
+                string rr;
+                string originalIP;
 
-                // 更新该记录的同步时间
-                item.LastSyncTime = DateTime.Now;
+                var domainName = item.Domain;
+                var domainTypeString = item.Type.ToString();
 
-                // 更新解析记录使用的请求，为了便于 catch 时获取相关数据，所以定义在 try 块外面
-                UpdateDomainRecordRequest updateRequest = null;
+                // 先用获取子域名的 API DescribeSubDomainRecordsRequest 进行尝试，如果查询不到该子域名，再尝试使用 DescribeDomainRecordsRequest 进行根域名查询
+                Console.WriteLine($"Try use sub domain api to search. SubDomain = {domainName}, Type = {domainTypeString}");
 
-                try
+                var subQueryRequest = new DescribeSubDomainRecordsRequest
                 {
-                    string recordId;
-                    string rr;
-                    string value;
+                    SubDomain = domainName,
+                    Type = domainTypeString
+                };
 
-                    var domainName = item.Domain;
-                    var domainTypeString = item.Type.ToString();
+                var subQueryResponse = Client.GetAcsResponse(subQueryRequest);
+                if (subQueryResponse.TotalCount > 0)
+                {
+                    Console.WriteLine("Is sub domain");
 
-                    // 先用获取子域名的 API DescribeSubDomainRecordsRequest 进行尝试，如果查询不到该子域名，再尝试使用 DescribeDomainRecordsRequest 进行根域名查询
-                    Console.WriteLine($"Try use sub domain api to search. SubDomain = {domainName}, Type = {domainTypeString}");
+                    // 虽然 DescribeSubDomainRecordsRequest 没有问题，安全起见还是过滤一下（具体问题参见后面 DescribeDomainRecordsRequest 的注释）
+                    var result = subQueryResponse.DomainRecords.SingleOrDefault(d => d.Type == domainTypeString);
+                    recordId = result?.RecordId;
+                    rr = result?.RR;
+                    originalIP = result?._Value;
+                }
+                else
+                {
+                    Console.WriteLine($"Not sub domain. Try use root domain api to search. SearchMode = EXACT, KeyWord = @, DomainName = {domainName}, TypeKeyWord = {domainTypeString}, Type = {domainTypeString}");
 
-                    var subQueryRequest = new DescribeSubDomainRecordsRequest
+                    // 由于 Type 和 TypeKeyWord 属性实测没有作用，过滤不了域名类型
+                    // 所以得到查询结果后还需要再手动过滤一次
+                    var rootQueryRequest = new DescribeDomainRecordsRequest
                     {
-                        SubDomain = domainName,
+                        SearchMode = "EXACT",
+                        DomainName = domainName,
+                        KeyWord = "@",
+                        TypeKeyWord = domainTypeString,
                         Type = domainTypeString
                     };
 
-                    var subQueryResponse = client.GetAcsResponse(subQueryRequest);
-                    if (subQueryResponse.TotalCount > 0)
-                    {
-                        Console.WriteLine("Is sub domain");
-
-                        // 虽然 DescribeSubDomainRecordsRequest 没有问题，安全起见还是过滤一下（具体问题参见后面 DescribeDomainRecordsRequest 的注释）
-                        var result = subQueryResponse.DomainRecords.SingleOrDefault(d => d.Type == domainTypeString);
-                        recordId = result?.RecordId;
-                        rr = result?.RR;
-                        value = result?._Value;
-                    }
-                    else
-                    {
-                        Console.WriteLine($"Not sub domain. Try use root domain api to search. SearchMode = EXACT, KeyWord = @, DomainName = {domainName}, TypeKeyWord = {domainTypeString}, Type = {domainTypeString}");
-
-                        // 由于 Type 和 TypeKeyWord 属性实测没有作用，过滤不了域名类型
-                        // 所以得到查询结果后还需要再手动过滤一次
-                        var rootQueryRequest = new DescribeDomainRecordsRequest
-                        {
-                            SearchMode = "EXACT",
-                            DomainName = domainName,
-                            KeyWord = "@",
-                            TypeKeyWord = domainTypeString,
-                            Type = domainTypeString
-                        };
-
-                        var rootQueryResponse = client.GetAcsResponse(rootQueryRequest);
-                        var result = rootQueryResponse.DomainRecords.SingleOrDefault(d => d.Type == domainTypeString);
-                        recordId = result?.RecordId;
-                        rr = result?.RR;
-                        value = result?._Value;
-                    }
-
-                    Console.WriteLine($"Search succeed: id = {recordId}, RR = {rr}, currentValue = {value}");
-
-                    if (recordId == null)
-                    {
-                        throw new KeyNotFoundException($"Update failed: cannot find a record for the domain name {item.Domain}.");
-                    }
-
-                    var address = IPHelper.GetAddress(item.Interface, item.AddressFamily);
-                    Console.WriteLine($"Interface {item.Interface} {item.AddressFamily} address is {address}");
-
-                    updateRequest = new UpdateDomainRecordRequest
-                    {
-                        RecordId = recordId,
-                        RR = rr,
-                        Type = domainTypeString,
-                        _Value = address
-                    };
-
-                    var updateResponse = client.GetAcsResponse(updateRequest);
-
-                    Console.WriteLine($"{item.Domain} updated successfully: {value} -> {address}");
-                    Console.WriteLine();
-
-                    item.IsLastSyncSuccess = true;
-                    item.LastSyncSuccessIP = address;
-                    item.LastSyncSuccessTime = DateTime.Now;
+                    var rootQueryResponse = Client.GetAcsResponse(rootQueryRequest);
+                    var result = rootQueryResponse.DomainRecords.SingleOrDefault(d => d.Type == domainTypeString);
+                    recordId = result?.RecordId;
+                    rr = result?.RR;
+                    originalIP = result?._Value;
                 }
-                catch (ClientException ex)
+
+                Console.WriteLine($"Search succeed: id = {recordId}, RR = {rr}, Value = {originalIP}");
+
+                if (recordId == null)
                 {
-                    // 如果更新时返回了 DomainRecordDuplicate 错误
-                    // 有可能是本地记录的 LastSyncSuccessIP 和机器实际的 IP 以及域名解析提供商一侧的地址不匹配（例如有段时间里程序没有执行，但 IP 发生了改变，就会造成 LastSyncSuccessIP 和提供商处的 IP 地址，以及实际地址不匹配）
-                    if (ex.ErrorCode == "DomainRecordDuplicate" && !String.IsNullOrEmpty(item.LastSyncSuccessIP) && updateRequest._Value != item.LastSyncSuccessIP)
-                    {
-                        item.IsLastSyncSuccess = false;
-                        item.LastSyncSuccessIP = updateRequest?._Value;
+                    throw new KeyNotFoundException($"Update failed: cannot find a record for the domain name {item.Domain}.");
+                }
 
-                        App.Out.WriteLine($"The update failed because the IP address recorded in the cache does not match the actual IP address and the IP address stored by the provider. The cache record has been updated, you can ignore this prompt.");
-                    }
-                    else
-                    {
-                        App.Error.WriteLine($"{item.Domain} update failed");
-                        App.Error.WriteLine(ex);
-                    }
-                }
-                catch (Exception ex)
-                {
-                    item.IsLastSyncSuccess = false;
+                var address = IPHelper.GetAddress(item.Interface, item.AddressFamily);
+                Console.WriteLine($"Interface {item.Interface} {item.AddressFamily} address is {address}");
 
-                    Console.WriteLine(ex);
-                }
-                finally
+                updateRequest = new UpdateDomainRecordRequest
                 {
-                    DomainConfigHelper.UpdateItem(item);
+                    RecordId = recordId,
+                    RR = rr,
+                    Type = domainTypeString,
+                    _Value = address
+                };
+
+                var updateResponse = Client.GetAcsResponse(updateRequest);
+
+                Console.WriteLine($"{item.Domain} updated successfully: {originalIP} -> {address}");
+
+                item.LastSyncStatus = SyncStatus.Success;
+                item.LastSyncSuccessOriginalIP = originalIP;
+                item.LastSyncSuccessCurrentIP = address;
+                item.LastSyncSuccessTime = DateTime.Now;
+            }
+            catch (ClientException ex)
+            {
+                // 如果更新时返回了 DomainRecordDuplicate 错误
+                // 有可能是本地记录的 LastSyncSuccessCurrentIP 和机器实际的 IP 以及域名解析提供商一侧的地址不匹配
+                // 例如有段时间里程序没有执行，但 IP 发生了改变，就会造成 LastSyncSuccessCurrentIP 和提供商处的 IP 地址，以及实际地址不匹配）
+                if (ex.ErrorCode == "DomainRecordDuplicate")
+                {
+                    item.LastSyncStatus = SyncStatus.Ignore;
+
+                    if (updateRequest._Value != item.LastSyncSuccessCurrentIP)
+                    {
+                        item.LastSyncSuccessCurrentIP = updateRequest?._Value;
+
+                        App.Out.WriteLine($"Update failed because the IP address recorded in the cache does not match the actual IP address and the IP address stored by the provider. The cache record has been updated, you can ignore this prompt.");
+
+                        return;
+                    }
+
+                    App.Out.WriteLine($"{ex.ErrorMessage} You can ignore this prompt.");
                 }
+                else
+                {
+                    throw;
+                }
+            }
+            finally
+            {
+                Console.WriteLine("--------------------");
             }
         }
     }

--- a/src/DDNSSharp/Providers/Cloudflare/CloudflareProvider.cs
+++ b/src/DDNSSharp/Providers/Cloudflare/CloudflareProvider.cs
@@ -1,5 +1,5 @@
 ﻿using DDNSSharp.Attributes;
-using DDNSSharp.Configs;
+using DDNSSharp.Commands.SyncCommands;
 using McMaster.Extensions.CommandLineUtils;
 using System.Collections.Generic;
 
@@ -19,7 +19,12 @@ namespace DDNSSharp.Providers.Cloudflare
             yield return new ProviderOption("--token", "Cloudflare Token", CommandOptionType.SingleValue);
         }
 
-        public override void Sync(IEnumerable<DomainConfigItem> domainConfigItems)
+        public override void BeforeSync()
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public override void Sync(SyncContext context)
         {
             throw new System.NotImplementedException();
         }

--- a/src/DDNSSharp/Providers/ProviderBase.cs
+++ b/src/DDNSSharp/Providers/ProviderBase.cs
@@ -1,4 +1,5 @@
 ﻿using DDNSSharp.Attributes;
+using DDNSSharp.Commands.SyncCommands;
 using DDNSSharp.Configs;
 using McMaster.Extensions.CommandLineUtils;
 using System;
@@ -87,7 +88,9 @@ namespace DDNSSharp.Providers
             }
         }
 
-        public abstract void Sync(IEnumerable<DomainConfigItem> domainConfigItems);
+        public abstract void BeforeSync();
+
+        public abstract void Sync(SyncContext context);
 
         /// <summary>
         /// 将当前 Provider 配置的更改写入配置文件中。

--- a/src/DDNSSharp/Providers/ProviderHelper.cs
+++ b/src/DDNSSharp/Providers/ProviderHelper.cs
@@ -83,6 +83,11 @@ namespace DDNSSharp.Providers
 
         public static IEnumerable<string> GetConfiguredProviderNames()
         {
+            if (!File.Exists(ProviderBase.PROVIDER_CONFIG_FILE_NAME))
+            {
+                yield break;
+            }
+
             var configBytes = File.ReadAllBytes(ProviderBase.PROVIDER_CONFIG_FILE_NAME);
             if (configBytes.Length == 0)
             {
@@ -108,6 +113,11 @@ namespace DDNSSharp.Providers
             if (providerName == null)
             {
                 throw new ArgumentNullException(nameof(providerName));
+            }
+
+            if (!File.Exists(ProviderBase.PROVIDER_CONFIG_FILE_NAME))
+            {
+                return null;
             }
 
             var configBytes = File.ReadAllBytes(ProviderBase.PROVIDER_CONFIG_FILE_NAME);


### PR DESCRIPTION
- 在域名配置文件 `domain.json` 中增加上次同步状态、上次同步时的 IP 等节点
- 在使用 `sync` 命令同步前，将与本地缓存（即 `domain.json` 文件）进行比较，只有当IP地址与缓存不一致时才同步到域名解析提供商
- 为 `sync` 命令增加 `--force` 强制同步选项，不论缓存和IP是否匹配，都同步到域名解析提供商