### PR TITLE
fix: 修复 #7 如果同步状态是 Ignore，通过 list 命令查看到的上次同步时间是错误的问题

### DIFF
--- a/src/DDNSSharp/Commands/Helpers/ListCommandHelper.cs
+++ b/src/DDNSSharp/Commands/Helpers/ListCommandHelper.cs
@@ -1,5 +1,5 @@
-﻿using DDNSSharp.Configs;
-using System;
+﻿using ConsoleTables;
+using DDNSSharp.Configs;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -12,28 +12,28 @@ namespace DDNSSharp.Commands.Helpers
         {
             if (configs.Any())
             {
-                const int MARGIN = 1;
-
-                var domainColWidh = configs.Max(c => c.Domain.Length) + MARGIN;
-                var typeColWidh = configs.Max(c => c.Type.ToString().Length) + MARGIN;
-                var interfaceColWidh = configs.Max(c => c.Interface.Length) + MARGIN;
-                var providerColWidh = configs.Max(c => c.Provider.Length) + MARGIN;
-                var lastSyncStatusColWidh = configs.Max(c => c.LastSyncStatus.ToString().Length) + MARGIN;
-                var lastSyncTimeColWidh = configs.Max(c => c.LastSyncTime.ToString().Length) + MARGIN;
+                var table = new ConsoleTable(
+                    nameof(DomainConfigItem.Domain),
+                    nameof(DomainConfigItem.Type),
+                    nameof(DomainConfigItem.Interface),
+                    nameof(DomainConfigItem.Provider),
+                    nameof(DomainConfigItem.LastSyncStatus),
+                    nameof(DomainConfigItem.LastSyncTime),
+                    nameof(DomainConfigItem.LastSyncSuccessTime));
 
                 foreach (var item in configs.OrderBy(c => c))
                 {
-                    output.WriteLine(
-                        "{1}|{0}{2}|{0}{3}|{0}{4}|{0}{5}|{0}{6}",
-                        String.Empty.PadRight(MARGIN),
-                        item.Domain.PadRight(domainColWidh),
-                        item.Type.ToString().PadRight(typeColWidh),
-                        item.Interface.PadRight(interfaceColWidh),
-                        item.Provider.PadRight(providerColWidh),
-                        item.LastSyncStatus.ToString().PadRight(lastSyncStatusColWidh),
-                        item.LastSyncTime.ToString().PadRight(lastSyncTimeColWidh)
-                    );
+                    table.AddRow(
+                        item.Domain,
+                        item.Type,
+                        item.Interface,
+                        item.Provider,
+                        item.LastSyncStatus,
+                        item.LastSyncTime,
+                        item.LastSyncSuccessTime);
                 }
+
+                table.Write(Format.Minimal);
             }
             else
             {

--- a/src/DDNSSharp/Commands/SyncCommand.cs
+++ b/src/DDNSSharp/Commands/SyncCommand.cs
@@ -29,6 +29,9 @@ namespace DDNSSharp.Commands
 
             foreach (var item in configs)
             {
+                // 更新该记录的同步时间
+                item.LastSyncTime = DateTime.Now;
+
                 var provider = ProviderHelper.GetInstanceByName(item.Provider, app);
                 console.Out.WriteLine($"Current domain: {item.Domain}");
 

--- a/src/DDNSSharp/DDNSSharp.csproj
+++ b/src/DDNSSharp/DDNSSharp.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="aliyun-net-sdk-alidns" Version="2.0.19" />
+    <PackageReference Include="ConsoleTables" Version="2.4.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
   </ItemGroup>

--- a/src/DDNSSharp/DDNSSharp.csproj
+++ b/src/DDNSSharp/DDNSSharp.csproj
@@ -12,6 +12,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <!-- 修正包降级错误 https://docs.microsoft.com/zh-cn/nuget/reference/errors-and-warnings/nu1605#example-2 -->
+    <PackageReference Include="Microsoft.NETCore.Targets" Version="3.0.0" PrivateAssets="all" />
     <PackageReference Include="aliyun-net-sdk-alidns" Version="2.0.19" />
     <PackageReference Include="ConsoleTables" Version="2.4.2" />
     <PackageReference Include="McMaster.Extensions.CommandLineUtils" Version="3.0.0" />

--- a/src/DDNSSharp/Providers/Aliyun/AliyunProvider.cs
+++ b/src/DDNSSharp/Providers/Aliyun/AliyunProvider.cs
@@ -33,9 +33,6 @@ namespace DDNSSharp.Providers.Aliyun
 
             var item = context.DomainConfigItem;
 
-            // 更新该记录的同步时间
-            item.LastSyncTime = DateTime.Now;
-
             // 更新解析记录使用的请求，为了便于 catch 时获取相关数据，所以定义在 try 块外面
             UpdateDomainRecordRequest updateRequest = null;
 


### PR DESCRIPTION
- 上次同步时间改为在调用 Provider 的 `Sync()` 方法前，由 DDNSSharp 统一设置
- 引入 ConsoleTables 进行控制台表格格式输出，并增加了上次成功时间的显示